### PR TITLE
CTX-3884: Fixed duplicate logs appearing in experiment console

### DIFF
--- a/src/coretex/project/base.py
+++ b/src/coretex/project/base.py
@@ -1,6 +1,6 @@
 #     Copyright (C) 2023  BioMech LLC
 
-#     This file is part of Coretex.ai  
+#     This file is part of Coretex.ai
 
 #     This program is free software: you can redistribute it and/or modify
 #     it under the terms of the GNU Affero General Public License as


### PR DESCRIPTION
Reintroduced Lock for uploading and appending logs

A while ago Lock was removed. Functions which had lock are following:
- appending
- flushing
- reset

The reason for why it was removed is if a network connection is lost, it takes a while for flushing request to timeout and reset method was blocked until that happened. To speed up this process I removed lock and introduced a different logic for uploading logs, but that appeared to be bugged.

To address this issue I reimplemented lock for appending and flushing of logs, as for reset it is not using lock. This should work properly since we call flush before reset in every scenarion and flush will block until the logs have been uploaded. If network connection is lost, it will timeout, but reset will do its job without blocking, since there is no reason to wait on flushing if the timeout will happen.