### PR TITLE
CTX-4915: Fixed centroid calculation

### DIFF
--- a/coretex/entities/annotation/image/coretex_format.py
+++ b/coretex/entities/annotation/image/coretex_format.py
@@ -121,7 +121,7 @@ class CoretexSegmentationInstance(Codable):
             draw = ImageDraw.Draw(image)
             draw.polygon(toPoly(segmentation), fill = 1)
 
-        return np.asarray(image)
+        return np.array(image)
 
     def extractBinaryMask(self, width: int, height: int) -> np.ndarray:
         """
@@ -156,10 +156,10 @@ class CoretexSegmentationInstance(Codable):
 
         flattenedSegmentations = [element for sublist in self.segmentations for element in sublist]
 
-        listCX = [value for index, value in enumerate(flattenedSegmentations) if index % 2 == 0]
+        listCX = [value for index, value in enumerate(flattenedSegmentations) if index % 2 == 0 and index < 8]
         centerX = sum(listCX) // len(listCX)
 
-        listCY = [value for index, value in enumerate(flattenedSegmentations) if index % 2 != 0]
+        listCY = [value for index, value in enumerate(flattenedSegmentations) if index % 2 != 0 and index < 8]
         centerY = sum(listCY) // len(listCY)
 
         return centerX, centerY


### PR DESCRIPTION
- Changed np.asarray(image), in extractSegmentationMask, to np.array(image) as the former would create a non writable ndarray, which would throw an error as that array is written into in extractBinaryMask
- In the centroid calculation, the top left coordinate (minX and minY) is counted twice in the averaging as it appears twice in the segmentations (indices 0, 1 and 8, 9)