### PR TITLE
CTX-5424: Incorrect name for docker image in config file fix.

### DIFF
--- a/coretex/cli/modules/ui.py
+++ b/coretex/cli/modules/ui.py
@@ -29,7 +29,7 @@ def previewConfig(config: Dict[str, Any]) -> None:
     table = [
         ["Node name", config["nodeName"]],
         ["Server URL", config["serverUrl"]],
-        ["Coretex Node type", config["nodeImage"]],
+        ["Coretex Node type", config["image"]],
         ["Storage path", config["storagePath"]],
         ["RAM", f"{config['nodeRam']}GB"],
         ["SWAP memory", f"{config['nodeSwap']}GB"],


### PR DESCRIPTION
Resolves CTX-5424