### PR TITLE
CLI-hotfix: Added CTX_MODEL_ID env variable to docker start.

### DIFF
--- a/coretex/cli/modules/docker.py
+++ b/coretex/cli/modules/docker.py
@@ -59,7 +59,8 @@ def start(
     nodeRam: int,
     nodeSwap: int,
     nodeSharedMemory: int,
-    nodeMode: int
+    nodeMode: int,
+    modelId: int
 ) -> None:
 
     runCommand = [
@@ -68,6 +69,7 @@ def start(
         "--env", f"CTX_STORAGE_PATH={storagePath}",
         "--env", f"CTX_NODE_ACCESS_TOKEN={nodeAccessToken}",
         "--env", f"CTX_NODE_MODE={nodeMode}",
+        "--env", f"CTX_MODEL_ID={modelId}",
         "--restart", 'always',
         "-p", "21000:21000",
         "--cap-add", "SYS_PTRACE",

--- a/coretex/cli/modules/node.py
+++ b/coretex/cli/modules/node.py
@@ -61,7 +61,8 @@ def start(dockerImage: str, config: Dict[str, Any]) -> None:
             config["nodeRam"],
             config["nodeSwap"],
             config["nodeSharedMemory"],
-            config["nodeMode"]
+            config["nodeMode"],
+            config["modelId"]
         )
         successEcho("Successfully started Coretex Node.")
     except BaseException as ex:


### PR DESCRIPTION
Fixes bug when trying to run functionExclusive node mode (CTX_MODEL_ID wasn't present in docker container).