### PR TITLE
CTX-4880: Bad output on node autoupdate fix...

### DIFF
--- a/coretex/cli/resources/update_script_template.sh
+++ b/coretex/cli/resources/update_script_template.sh
@@ -50,15 +50,17 @@ OUTPUT_FILE="$OUTPUT_DIR/ctx_autoupdate.log"
 exec >>"$OUTPUT_FILE" 2>&1
 
 fetch_node_status() {{
+    fetched_status=0
     api_response=$(curl -s "$NODE_STATUS_ENDPOINT")
-    status=$(echo "$api_response" | sed -n 's/.*"status":\([^,}}]*\).*/\1/p')
-    echo "$status"
+    fetched_status=$(echo "$api_response" | sed -n 's/.*"status":\([^,}}]*\).*/\1/p')
+    echo "$fetched_status"
 }}
 
 should_update() {{
-    status=$(fetch_node_status)
+    node_status=0
+    node_status=$(fetch_node_status)
 
-    if [ "$status" -eq 2 ]; then
+    if [ "$node_status" -eq 2 ]; then
         echo "Checking node version..."
         # Get latest image digest from docker hub
         manifest_output=$($DOCKER_PATH manifest inspect $REPOSITORY:$TAG --verbose)
@@ -134,9 +136,10 @@ start_node() {{
 
 # Define function to update node
 update_node() {{
-    status=$(fetch_node_status)
+    current_node_status=0
+    current_node_status=$(fetch_node_status)
 
-    if [ "$status" -eq 3 ]; then
+    if [ "$current_node_status" -eq 3 ]; then
         echo "Node is busy, stopping node update."
         return 1
     fi

--- a/coretex/cli/resources/update_script_template.sh
+++ b/coretex/cli/resources/update_script_template.sh
@@ -49,14 +49,14 @@ OUTPUT_FILE="$OUTPUT_DIR/ctx_autoupdate.log"
 # Redirect all output to the file
 exec >>"$OUTPUT_FILE" 2>&1
 
-function fetch_node_status {{
-    local api_response=$(curl -s "$NODE_STATUS_ENDPOINT")
-    local status=$(echo "$api_response" | sed -n 's/.*"status":\([^,}}]*\).*/\1/p')
+fetch_node_status() {{
+    api_response=$(curl -s "$NODE_STATUS_ENDPOINT")
+    status=$(echo "$api_response" | sed -n 's/.*"status":\([^,}}]*\).*/\1/p')
     echo "$status"
 }}
 
-function should_update {{
-    local status=$(fetch_node_status)
+should_update() {{
+    status=$(fetch_node_status)
 
     if [ "$status" -eq 2 ]; then
         echo "Checking node version..."
@@ -84,7 +84,7 @@ function should_update {{
     fi
 }}
 
-function pull_image {{
+pull_image() {{
     if $DOCKER_PATH image pull "$IMAGE"; then
         echo "Image pulled successfully: $IMAGE"
         return 0
@@ -94,8 +94,8 @@ function pull_image {{
     fi
 }}
 
-# Define function to stop and remove the container
-function stop_node {{
+# Define to stop and remove the container
+stop_node() {{
     echo "Stopping and removing the container: $CONTAINER_NAME"
     $DOCKER_PATH stop "$CONTAINER_NAME" && $DOCKER_PATH rm "$CONTAINER_NAME"
 
@@ -107,8 +107,8 @@ function stop_node {{
     echo "Node successfully stopped."
 }}
 
-# Define function to start the node with the latest image
-function start_node {{
+# Define to start the node with the latest image
+start_node() {{
     if $DOCKER_PATH network inspect $NETWORK_NAME; then
         echo "Removing the network: $NETWORK_NAME"
         $DOCKER_PATH network rm "$NETWORK_NAME"
@@ -132,9 +132,9 @@ function start_node {{
     eval "$start_command"
 }}
 
-# Define function to update node
-function update_node {{
-    local status=$(fetch_node_status)
+# Define to update node
+update_node() {{
+    status=$(fetch_node_status)
 
     if [ "$status" -eq 3 ]; then
         echo "Node is busy, stopping node update."
@@ -157,12 +157,12 @@ function update_node {{
     start_node
 }}
 
-# Function to run node update
-function run_node_update {{
+# to run node update
+run_node_update() {{
     echo "Running command: update_node"
     update_node
 
-    local exit_code=$?
+    exit_code=$?
     if [ "$exit_code" -eq 0 ]; then
         echo "Node update finished successfully"
     else

--- a/coretex/cli/resources/update_script_template.sh
+++ b/coretex/cli/resources/update_script_template.sh
@@ -94,7 +94,7 @@ pull_image() {{
     fi
 }}
 
-# Define to stop and remove the container
+# Define function to stop and remove the container
 stop_node() {{
     echo "Stopping and removing the container: $CONTAINER_NAME"
     $DOCKER_PATH stop "$CONTAINER_NAME" && $DOCKER_PATH rm "$CONTAINER_NAME"
@@ -107,7 +107,7 @@ stop_node() {{
     echo "Node successfully stopped."
 }}
 
-# Define to start the node with the latest image
+# Define function to start the node with the latest image
 start_node() {{
     if $DOCKER_PATH network inspect $NETWORK_NAME; then
         echo "Removing the network: $NETWORK_NAME"
@@ -132,7 +132,7 @@ start_node() {{
     eval "$start_command"
 }}
 
-# Define to update node
+# Define function to update node
 update_node() {{
     status=$(fetch_node_status)
 
@@ -157,7 +157,7 @@ update_node() {{
     start_node
 }}
 
-# to run node update
+# function to run node update
 run_node_update() {{
     echo "Running command: update_node"
     update_node


### PR DESCRIPTION
Bad output from machines fix (node was up to date but it was showing strange errors...). The issue arises because sh is more restrictive compared to bash. It doesn't support some Bash-specific features, such as the function keyword and the local keyword used for declaring local variables within functions.