### PR TITLE
CTX-5758: Always use the same entry point for starting the Node.

### DIFF
--- a/coretex/cli/commands/node.py
+++ b/coretex/cli/commands/node.py
@@ -21,9 +21,10 @@ import click
 
 from ..modules import node as node_module
 from ..modules.ui import clickPrompt, stdEcho, successEcho, errorEcho, previewConfig
-from ..modules.update import NodeStatus, getNodeStatus, activateAutoUpdate, dumpScript, UPDATE_SCRIPT_NAME
+from ..modules.update import NodeStatus, getNodeStatus, activateAutoUpdate, dumpScript
 from ..modules.utils import onBeforeCommandExecute
 from ..modules.user import initializeUserSession
+from ..resources import START_SCRIPT_NAME
 from ...configuration import loadConfig, saveConfig, CONFIG_DIR, isNodeConfigured
 from ...utils import docker
 
@@ -54,8 +55,7 @@ def start(image: Optional[str]) -> None:
 
     dockerImage = config["image"]
 
-    if node_module.shouldUpdate(dockerImage):
-        node_module.pull(dockerImage)
+    dumpScript(CONFIG_DIR / START_SCRIPT_NAME, config)
 
     node_module.start(dockerImage, config)
     docker.removeDanglingImages(node_module.getRepoFromImageUrl(dockerImage), node_module.getTagFromImageUrl(dockerImage))
@@ -152,7 +152,7 @@ def config(verbose: bool) -> None:
     previewConfig(config)
 
     # Updating auto-update script since node configuration is changed
-    dumpScript(CONFIG_DIR / UPDATE_SCRIPT_NAME, config)
+    dumpScript(CONFIG_DIR / START_SCRIPT_NAME, config)
 
     successEcho("Node successfully configured.")
 

--- a/coretex/cli/modules/update.py
+++ b/coretex/cli/modules/update.py
@@ -24,12 +24,9 @@ import requests
 from . import config_defaults
 from .cron import jobExists, scheduleJob
 from .node import getRepoFromImageUrl, getTagFromImageUrl
-from ..resources import RESOURCES_DIR
+from ..resources import RESOURCES_DIR, START_SCRIPT_NAME
 from ...utils import command
 from ...configuration import CONFIG_DIR, getInitScript
-
-
-UPDATE_SCRIPT_NAME = "ctx_node_update.sh"
 
 
 class NodeStatus(IntEnum):
@@ -81,11 +78,11 @@ def dumpScript(updateScriptPath: Path, config: Dict[str, Any]) -> None:
 
 
 def activateAutoUpdate(configDir: Path, config: Dict[str, Any]) -> None:
-    updateScriptPath = CONFIG_DIR / UPDATE_SCRIPT_NAME
+    updateScriptPath = CONFIG_DIR / START_SCRIPT_NAME
     dumpScript(updateScriptPath, config)
 
-    if not jobExists(UPDATE_SCRIPT_NAME):
-        scheduleJob(configDir, UPDATE_SCRIPT_NAME)
+    if not jobExists(START_SCRIPT_NAME):
+        scheduleJob(configDir, START_SCRIPT_NAME)
 
 
 def getNodeStatus() -> NodeStatus:

--- a/coretex/cli/resources/__init__.py
+++ b/coretex/cli/resources/__init__.py
@@ -15,4 +15,4 @@
 #     You should have received a copy of the GNU Affero General Public License
 #     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from .resources import RESOURCES_DIR
+from .resources import RESOURCES_DIR, START_SCRIPT_NAME

--- a/coretex/cli/resources/resources.py
+++ b/coretex/cli/resources/resources.py
@@ -19,3 +19,4 @@ from pathlib import Path
 
 
 RESOURCES_DIR = Path(__file__).resolve().parent
+START_SCRIPT_NAME = "start_node.sh"


### PR DESCRIPTION
Optimized a CLI flow a bit since there is no more need for double corrections when something in flow changes related to starting the node (only bash template script will be changed nothing more). If actual command for start of the node is called (coretex node start) --force flag is passed to the bash script (since when auto update is performed we don't want that to happen if node is not active, which is not the case here). Rest is the same, formatted code a bit to have more sense.

Resolves CTX-5758.