### PR TITLE
CTX-6062: Improve containerRunning() function so it splits the lines …

### DIFF
--- a/coretex/utils/docker.py
+++ b/coretex/utils/docker.py
@@ -29,7 +29,7 @@ def networkExists(name: str) -> bool:
 def containerRunning(name: str) -> bool:
     try:
         _, output, _ = command(["docker", "ps", "--format", "{{.Names}}"], ignoreStderr = True, ignoreStdout = True)
-        return name in output
+        return name in output.splitlines()
     except:
         return False
 


### PR DESCRIPTION
…(docker container names) and creates a list of it. If name (coretex_node) is in the list of docker container names that means coretex_node container is active.