### PR TITLE
CTX-6062: Fix for issues with starting/stopping container when there is multiple containers with "coretex_node" chars in name.

### DIFF
--- a/coretex/utils/docker.py
+++ b/coretex/utils/docker.py
@@ -29,7 +29,7 @@ def networkExists(name: str) -> bool:
 def containerRunning(name: str) -> bool:
     try:
         _, output, _ = command(["docker", "ps", "--format", "{{.Names}}"], ignoreStderr = True, ignoreStdout = True)
-        return name in output
+        return name in output.splitlines()
     except:
         return False
 

--- a/coretex/utils/docker.py
+++ b/coretex/utils/docker.py
@@ -37,7 +37,7 @@ def containerRunning(name: str) -> bool:
 def containerExists(name: str) -> bool:
     try:
         _, output, _ = command(["docker", "ps", "-a", "--format", "{{.Names}}"], ignoreStderr = True, ignoreStdout = True)
-        return name in output
+        return name in output.splitlines()
     except:
         return False
 


### PR DESCRIPTION
Resolves CTX-6062.